### PR TITLE
Implement email control configs

### DIFF
--- a/mail/mailer_test.go
+++ b/mail/mailer_test.go
@@ -14,7 +14,7 @@ func TestSendMessageToNonMemberWithoutLogging(t *testing.T) {
 	m := mailApiMock{}
 	c, _ := config.Load()
 
-	mailer := NewMailer(&db, m, c)
+	mailer := NewMailer(&db, &m, c)
 	mailer.generator = generatorMock{}
 
 	db.memberError = pgx.ErrNoRows
@@ -37,7 +37,7 @@ func TestSendMessageToMemberShouldLog(t *testing.T) {
 	m := mailApiMock{}
 	c, _ := config.Load()
 
-	mailer := NewMailer(&db, m, c)
+	mailer := NewMailer(&db, &m, c)
 	mailer.generator = generatorMock{}
 
 	sent, err := mailer.SendCommunication(AccessRevokedLeadership, "member@hackrva.org", memberModel)
@@ -58,7 +58,7 @@ func TestSendMessageToShouldThrottle(t *testing.T) {
 	m := mailApiMock{}
 	c, _ := config.Load()
 
-	mailer := NewMailer(&db, m, c)
+	mailer := NewMailer(&db, &m, c)
 	mailer.generator = generatorMock{}
 	db.communicationResult.FrequencyThrottle = 10
 	db.mostRecentCommResult = time.Now().AddDate(0, 0, -5)
@@ -73,6 +73,92 @@ func TestSendMessageToShouldThrottle(t *testing.T) {
 
 	if db.logCommunicationCalled {
 		t.Error("Log should not be created since communication was not sent")
+	}
+}
+
+func TestEnableMemberEmailsSetShouldSendMemberEmails(t *testing.T) {
+	db := dbMock{}
+	m := mailApiMock{}
+	c, _ := config.Load()
+	c.EnableNotificationEmailsToMembers = true
+
+	mailer := NewMailer(&db, &m, c)
+	mailer.generator = generatorMock{}
+
+	sent, err := mailer.SendCommunication(AccessRevokedMember, "member@email.com", memberModel)
+	if err != nil {
+		t.Errorf("Error sending communication %v", err)
+	}
+	if !sent {
+		t.Error("Mail not sent")
+	}
+	if !m.MailSent {
+		t.Error("Mail not sent")
+	}
+}
+
+func TestEnableMemberEmailsUnsetShouldNotSendMemberEmails(t *testing.T) {
+	db := dbMock{}
+	m := mailApiMock{}
+	c, _ := config.Load()
+	c.EnableNotificationEmailsToMembers = false
+
+	mailer := NewMailer(&db, &m, c)
+	mailer.generator = generatorMock{}
+
+	sent, err := mailer.SendCommunication(AccessRevokedMember, "member@email.com", memberModel)
+	if err != nil {
+		t.Errorf("Error sending communication %v", err)
+	}
+	if sent {
+		t.Error("Mail should not be sent")
+	}
+	if m.MailSent {
+		t.Error("Mail should not be sent")
+	}
+}
+
+func TestEnableInfoEmailsSetShouldSendInfoEmails(t *testing.T) {
+	db := dbMock{}
+	m := mailApiMock{}
+	c, _ := config.Load()
+	c.EnableInfoEmails = true
+	db.memberError = pgx.ErrNoRows
+
+	mailer := NewMailer(&db, &m, c)
+	mailer.generator = generatorMock{}
+
+	sent, err := mailer.SendCommunication(AccessRevokedMember, c.AdminEmail, memberModel)
+	if err != nil {
+		t.Errorf("Error sending communication %v", err)
+	}
+	if !sent {
+		t.Error("Mail should not be sent")
+	}
+	if !m.MailSent {
+		t.Error("Mail should not be sent")
+	}
+}
+
+func TestEnableInfoEmailsUnsetShouldNotSendInfoEmails(t *testing.T) {
+	db := dbMock{}
+	m := mailApiMock{}
+	c, _ := config.Load()
+	c.EnableInfoEmails = false
+	db.memberError = pgx.ErrNoRows
+
+	mailer := NewMailer(&db, &m, c)
+	mailer.generator = generatorMock{}
+
+	sent, err := mailer.SendCommunication(AccessRevokedMember, c.AdminEmail, memberModel)
+	if err != nil {
+		t.Errorf("Error sending communication %v", err)
+	}
+	if sent {
+		t.Error("Mail should not be sent")
+	}
+	if m.MailSent {
+		t.Error("Mail should not be sent")
 	}
 }
 
@@ -100,12 +186,16 @@ func (m *dbMock) GetMostRecentCommunicationToMember(memberId string, commId int)
 	return m.mostRecentCommResult, m.mostRecentCommError
 }
 
-type mailApiMock struct{}
+type mailApiMock struct {
+	MailSent bool
+}
 
-func (m mailApiMock) SendHtmlMail(address, subject, body string) (string, error) {
+func (m *mailApiMock) SendHtmlMail(address, subject, body string) (string, error) {
+	m.MailSent = true
 	return "", nil
 }
-func (m mailApiMock) SendPlainTextMail(address, subject, content string) (string, error) {
+func (m *mailApiMock) SendPlainTextMail(address, subject, content string) (string, error) {
+	m.MailSent = true
 	return "", nil
 }
 

--- a/memberserver.example.env
+++ b/memberserver.example.env
@@ -14,3 +14,5 @@ MQTT_BROKER_ADDRESS=tcp://mosquitto:1883
 DB_CONNECTION_STRING=postgresql://test:test@postgres:5432/membership
 SLACK_TOKEN=localSLACK_TOKEN
 ALWAYS_ADMIN=true
+ENABLE_INFO_EMAILS=true
+ENABLE_MEMBER_EMAILS=true


### PR DESCRIPTION
Configures whether emails are enabled using environment variables ENABLE_INFO_EMAILS and ENABLE_MEMBER_EMAILS.
fixes #36 