### PR TITLE
remove type mod in package.json

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -60,6 +60,5 @@
     "rollup-plugin-filesize": "^9.1.1",
     "rollup-plugin-terser": "^7.0.2",
     "typescript": "^4.2.4"
-  },
-  "type": "module"
+  }
 }


### PR DESCRIPTION
Removing `type: module` will allow us to no longer be concerned with the proxy. Allowing us to use later version of node for local dev