### PR TITLE
delete inactive rfid fobs from rfid devices

### DIFF
--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -104,6 +104,7 @@ func checkMemberStatus() {
 			}
 		}
 	}
+	rm.RemovedInvalidUIDs()
 }
 
 func checkResourceInit() {


### PR DESCRIPTION
inactive rfid fobs should be removed from the RFID devices.
It's kind of the whole point