### PR TITLE
remove a users old rfid fob if they are assigning a new one

### DIFF
--- a/resourcemanager/mqttHandlers.go
+++ b/resourcemanager/mqttHandlers.go
@@ -37,7 +37,10 @@ var HealthCheck mqtt.MessageHandler = func(client mqtt.Client, msg mqtt.Message)
 		return
 	}
 	accessList, err := db.GetResourceACL(r)
-
+	if err != nil {
+		log.Error(err)
+		return
+	}
 	// log.Debugf("body= %s json=%s accessListHash=%s name=%s", string(msg.Payload()), acl.Hash, hash(accessList), acl.Name)
 
 	if acl.Hash != hash(accessList) {

--- a/resourcemanager/resourcemanager.go
+++ b/resourcemanager/resourcemanager.go
@@ -105,16 +105,19 @@ func (rm *ResourceManager) RemovedInvalidUIDs() {
 
 	for _, m := range inactiveMembers {
 		/* We will just try to remove all invalid members even if they are already removed */
-		b, _ := json.Marshal(&models.MemberRequest{
-			ResourceAddress: m.ResourceAddress,
-			Command:         commandDeleteUID,
-			RFID:            m.RFID,
-		})
-		rm.MQTTServer.Publish(m.ResourceName, string(b))
-		log.Debugf("attempting to remove member %s from rfid device %s : %s", m.Email, m.ResourceName, m.ResourceAddress)
-
+		rm.RemoveMember(m)
 		time.Sleep(2 * time.Second)
 	}
+}
+
+func (rm *ResourceManager) RemoveMember(memberAccess models.MemberAccess) {
+	b, _ := json.Marshal(&models.MemberRequest{
+		ResourceAddress: memberAccess.ResourceAddress,
+		Command:         commandDeleteUID,
+		RFID:            memberAccess.RFID,
+	})
+	rm.MQTTServer.Publish(memberAccess.ResourceName, string(b))
+	log.Debugf("attempting to remove member %s from rfid device %s : %s", memberAccess.Email, memberAccess.ResourceName, memberAccess.ResourceAddress)
 }
 
 func (rm *ResourceManager) Open(resource models.Resource) {


### PR DESCRIPTION
When a member goes to assign a new rfid fob, we should remove access to the old one (if they have an old one)