### PR TITLE
fixing open door mqtt request

### DIFF
--- a/api/models/resource.go
+++ b/api/models/resource.go
@@ -63,6 +63,7 @@ type MemberRequest struct {
 type MQTTRequest struct {
 	Door    string `json:"door"`
 	Command string `json:"cmd"`
+	Address string `json:"doorip"`
 }
 
 type DeleteMemberRequest struct {

--- a/resourcemanager/resourcemanager.go
+++ b/resourcemanager/resourcemanager.go
@@ -124,6 +124,7 @@ func (rm *ResourceManager) Open(resource models.Resource) {
 	b, _ := json.Marshal(models.MQTTRequest{
 		Door:    resource.Name,
 		Command: commandOpenDoor,
+		Address: resource.Address,
 	})
 
 	rm.MQTTServer.Publish(resource.Name, string(b))


### PR DESCRIPTION
- adding resourceAddress to open door mqtt request

request should follow this format
`'{"door":"frontdoor","cmd":"opendoor", "doorip": "<IP OF THE RESOURCE>"}'`