### PR TITLE
Enable admins to optionally include a subId when creating a new member

### DIFF
--- a/web/src/app/shared/components/member-rfid-management/member-rfid-management.component.html
+++ b/web/src/app/shared/components/member-rfid-management/member-rfid-management.component.html
@@ -23,6 +23,10 @@
     </mat-form-field>
 
     @if(memberRFIDType === rfidType.New) {
+    <mat-form-field appearance="outline">
+      <mat-label>Subscription ID</mat-label>
+      <input matInput formControlName="subscriptionID" />
+    </mat-form-field>
     <p>
       This is an option if the new member's info hasn't been sent from paypal
       yet. Check the table before trying to add them manually.

--- a/web/src/app/shared/components/member-rfid-management/member-rfid-management.component.ts
+++ b/web/src/app/shared/components/member-rfid-management/member-rfid-management.component.ts
@@ -49,6 +49,7 @@ export class MemberRFIDManagementComponent implements OnInit {
       Validators.email,
     ]),
     rfid: new FormControl<number>(null, [Validators.required]),
+    subscriptionID: new FormControl<string>(null),
   });
 
   constructor(
@@ -82,6 +83,7 @@ export class MemberRFIDManagementComponent implements OnInit {
         memberObs$ = this.memberService.assignNewMemberRFID({
           ...request,
           name: this.rfidManagementGroup.get('name').value,
+          subscriptionID: this.rfidManagementGroup.get('subscriptionID').value,
         });
         break;
       case RFIDManagementType.Edit:

--- a/web/src/app/shared/types/member.types.ts
+++ b/web/src/app/shared/types/member.types.ts
@@ -33,7 +33,10 @@ export type AssignRFIDRequest = {
   rfid: string;
 };
 
-export type CreateMemberRequest = AssignRFIDRequest & { name: string };
+export type CreateMemberRequest = AssignRFIDRequest & {
+  name: string;
+  subscriptionID: string;
+};
 
 export type UpdateMemberRequest = {
   fullName: string;


### PR DESCRIPTION
## Description
Enable admins to optionally include a subscriptionId when creating a new member

Fixes # (issue)

## Type of change
Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
